### PR TITLE
Feature/tao 4232 exit button

### DIFF
--- a/controller/Monitor.php
+++ b/controller/Monitor.php
@@ -38,6 +38,12 @@ class Monitor extends SimplePageModule
             'defaultTag' => (string)$this->getDefaultTag(),
         ];
 
+        $session = \common_session_SessionManager::getSession();
+        if ($session instanceof \taoLti_models_classes_TaoLtiSession) {
+            $launchData = $session->getLaunchData();
+            $params['exitUrl'] = $launchData->getReturnUrl();
+        }
+
         if (!is_null($delivery)) {
             $params['delivery'] = $delivery->getUri();
         }

--- a/manifest.php
+++ b/manifest.php
@@ -36,11 +36,11 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '1.1.2',
+    'version' => '1.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoLti' => '>=1.11.0',
-        'taoProctoring' => '>=4.17.0',
+        'taoProctoring' => '>=4.21.0',
         'ltiDeliveryProvider' => '>=2.7.0',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#ltiProctoringManager',

--- a/model/LtiGuiSettingsService.php
+++ b/model/LtiGuiSettingsService.php
@@ -14,35 +14,35 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
- *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
  *
  */
-namespace oat\ltiProctoring\controller;
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+namespace oat\ltiProctoring\model;
+
+use oat\taoProctoring\model\GuiSettingsService;
 
 /**
- * LTI monitoring controller
- * 
- * @author joel bout
+ * Class LtiGuiSettingsService
+ * @package oat\ltiProctoring\model
  */
-class Monitor extends SimplePageModule
+class LtiGuiSettingsService extends GuiSettingsService
 {
     /**
-     * Monitoring view of a selected delivery
+     * Gets the URL that exits the proctor pages
+     * @return string|null
      */
-    public function index()
+    public function getExitUrl()
     {
-        $delivery = $this->getCurrentDelivery();
-
-        $params = [
-            'defaultTag' => (string)$this->getDefaultTag(),
-        ];
-
-        if (!is_null($delivery)) {
-            $params['delivery'] = $delivery->getUri();
+        $session = \common_session_SessionManager::getSession();
+        if ($session instanceof \taoLti_models_classes_TaoLtiSession) {
+            $launchData = $session->getLaunchData();
+            return $launchData->getReturnUrl();
         }
-
-        $this->setClientRoute(_url('index', 'Monitor', 'taoProctoring', $params));
-        $this->composeView('delegated-view', null, 'pages/index.tpl', 'tao');
+        
+        return parent::getExitUrl();
     }
 }

--- a/scripts/install/RegisterLtiGuiSettingsService.php
+++ b/scripts/install/RegisterLtiGuiSettingsService.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA ;
+ *
+ */
+/**
+ * @author Jean-Sébastien Conan <jean-sebastien@taotesting.com>
+ */
+
+namespace oat\ltiProctoring\scripts\install;
+
+use oat\ltiProctoring\model\LtiGuiSettingsService;
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\service\ServiceNotFoundException;
+use oat\taoProctoring\model\GuiSettingsService;
+
+/**
+ * Class RegisterLtiGuiSettingsService
+ * @package oat\ltiProctoring\scripts\install
+ */
+class RegisterLtiGuiSettingsService extends InstallAction
+{
+
+    /**
+     * Configure and register the GuiSettingsService
+     */
+    public function __invoke($params)
+    {
+        try {
+            $options = $this->getServiceManager()->get(GuiSettingsService::SERVICE_ID)->getOptions();
+        } catch(ServiceNotFoundException $e) {
+            $options = [
+                GuiSettingsService::PROCTORING_REFRESH_BUTTON => true,
+                GuiSettingsService::PROCTORING_AUTO_REFRESH => 0,
+                GuiSettingsService::PROCTORING_ALLOW_PAUSE => true,
+            ];
+        }
+        
+        $service = new LtiGuiSettingsService($options);
+        $this->getServiceManager()->propagate($service);
+        $this->getServiceManager()->register(GuiSettingsService::SERVICE_ID, $service);
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -114,6 +114,7 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->getServiceManager()->register(ActivityMonitoringService::SERVICE_ID, $newService);
             $this->setVersion('1.1.1');
         }
-        $this->skip('1.1.1', '1.1.2');
+        
+        $this->skip('1.1.1', '1.2.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -7,6 +7,7 @@ use oat\ltiProctoring\controller\Reporting;
 use oat\ltiProctoring\model\LtiListenerService;
 use oat\ltiProctoring\model\execution\LtiDeliveryExecutionService;
 use oat\ltiProctoring\model\implementation\TestSessionHistoryService;
+use oat\ltiProctoring\scripts\install\RegisterLtiGuiSettingsService;
 use oat\oatbox\event\EventManager;
 use oat\tao\scripts\update\OntologyUpdater;
 use oat\taoDelivery\model\authorization\AuthorizationService as DeliveryAuthorizationService;
@@ -115,6 +116,11 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('1.1.1');
         }
         
-        $this->skip('1.1.1', '1.2.0');
+        $this->skip('1.1.1', '1.1.2');
+
+        if ($this->isVersion('1.1.2')) {
+            $this->runExtensionScript(RegisterLtiGuiSettingsService::class);
+            $this->setVersion('1.2.0');
+        }
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4232

Requires: https://github.com/oat-sa/extension-tao-proctoring/pull/352

Overrides the GuiSettingsService to set the `exitUrl` and to display the exit button while in LTI session.