### PR TITLE
Act 106/corresponce of resource id and delivery execution

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -21,13 +21,16 @@
 
 namespace oat\ltiProctoring\controller;
 
-use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoProctoring\controller\DeliveryServer as ProctoringDeliveryServer;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoLti\models\classes\LtiMessages\LtiMessage;
 use oat\taoProctoring\model\deliveryLog\DeliveryLog;
 use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
 use oat\ltiDeliveryProvider\model\LTIDeliveryTool;
+use oat\taoLti\models\classes\LtiService;
+use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
+use oat\taoLti\models\classes\LtiException;
+use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 
 /**
  * Override the default DeliveryServer Controller
@@ -52,12 +55,7 @@ class DeliveryServer extends ProctoringDeliveryServer
      */
     public function finishDeliveryExecution()
     {
-        $deliveryExecution = null;
-        if ($this->hasRequestParameter('deliveryExecution')) {
-            $deliveryExecution = ServiceProxy::singleton()->getDeliveryExecution(
-                $this->getRequestParameter('deliveryExecution')
-            );
-        }
+        $deliveryExecution = $this->getCurrentDeliveryExecution();
         if ($deliveryExecution->getState()->getUri() == ProctoredDeliveryExecution::STATE_PAUSED) {
             $redirectUrl = _url('awaitingAuthorization', 'DeliveryServer', 'ltiProctoring', ['deliveryExecution' => $deliveryExecution->getIdentifier()]);
         } else {
@@ -122,6 +120,31 @@ class DeliveryServer extends ProctoringDeliveryServer
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         return _url('finishDeliveryExecution', 'DeliveryServer', 'ltiProctoring',
             ['deliveryExecution' => $deliveryExecution->getIdentifier()]
+        );
+    }
+
+    /**
+     * @return DeliveryExecution
+     * @throws
+     */
+    protected function getCurrentDeliveryExecution()
+    {
+        $deliveryExecution = parent::getCurrentDeliveryExecution();
+        $link = LtiService::singleton()->getLtiSession()->getLtiLinkResource();
+        $user = \common_session_SessionManager::getSession()->getUser();
+        /** @var LtiDeliveryExecutionService $deliveryExecutionService */
+        $deliveryExecutionService = $this->getServiceLocator()->get(LtiDeliveryExecutionService::SERVICE_ID);
+        $linkedDeliveryExecutions = $deliveryExecutionService->getLinkedDeliveryExecutions($deliveryExecution->getDelivery(), $link, $user->getIdentifier());
+
+        foreach ($linkedDeliveryExecutions as $linkedDeliveryExecution) {
+            if ($linkedDeliveryExecution->getIdentifier() === $deliveryExecution->getIdentifier()) {
+                return $deliveryExecution;
+            }
+        }
+
+        throw new LtiException(
+            'Delivery execution identifier is not linked with current resource_link_id',
+            LtiErrorMessage::ERROR_INVALID_PARAMETER
         );
     }
 }

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -31,6 +31,7 @@ use oat\taoLti\models\classes\LtiService;
 use oat\ltiDeliveryProvider\model\execution\LtiDeliveryExecutionService;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
+use oat\taoLti\models\classes\LtiVariableMissingException;
 
 /**
  * Override the default DeliveryServer Controller
@@ -125,7 +126,8 @@ class DeliveryServer extends ProctoringDeliveryServer
 
     /**
      * @return DeliveryExecution
-     * @throws
+     * @throws LtiException if given delivery exection does not correspond to current lti session
+     * @throws \Exception
      */
     protected function getCurrentDeliveryExecution()
     {

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '3.8.0',
+    'version' => '3.8.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'taoLti' => '>=5.0.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -193,6 +193,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.5.0');
         }
 
-        $this->skip('3.5.0', '3.8.0');
+        $this->skip('3.5.0', '3.8.1');
     }
 }


### PR DESCRIPTION
Steps to reproduce the issue:

1. Add Resource ID value to the Return Url. It should be something like: http://ltiapps.net/test/tc-return.php?r_id=4297852261571
2. Launch test A, while on awaiting screen copy URL from browser's address bar. Finish the test.
3. Update Resource ID value in Resource ID input and in Return Url input
2. Launch test B, while on awaiting screen paste copied URL from step 1 to the browser's address bar, press enter.

User will be redirected to LTI return URL. Registration ID in this URL will be from launch 2 but delivery execution id from launch 1.
