### PR TITLE
Feature/tao 7389/store lti delivery execution context

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,8 +41,9 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',
-        'taoLti' => '>=7.1.0',
-        'taoProctoring' => '>=12.2.0',
+        'taoLti' => '>=8.6.1',
+        'taoProctoring' => '>=12.7.0',
+        'taoDelivery' => '>=12.5.0',
         'ltiDeliveryProvider' => '>=7.0.0',
     ),
     'managementRole' => 'http://www.tao.lu/Ontologies/generis.rdf#ltiProctoringManager',

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '5.1.1',
+    'version' => '5.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',

--- a/model/LtiListenerService.php
+++ b/model/LtiListenerService.php
@@ -24,6 +24,7 @@ use oat\ltiProctoring\model\delivery\ProctorService;
 use oat\ltiProctoring\model\execution\LtiDeliveryExecutionContext;
 use oat\oatbox\service\ConfigurableService;
 use oat\taoDelivery\model\execution\DeliveryExecutionContext;
+use oat\taoDelivery\model\execution\DeliveryExecutionContextInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
@@ -87,13 +88,11 @@ class LtiListenerService extends ConfigurableService
             try {
                 $contextId = $launchData->getVariable(LtiLaunchData::CONTEXT_ID);
                 $data->update(LtiLaunchData::CONTEXT_ID, $contextId);
-                $executionContext = new DeliveryExecutionContext(
-                    $executionId,
-                    $contextId,
-                    LtiDeliveryExecutionContext::EXECUTION_CONTEXT_TYPE,
-                    $launchData->getVariable(LtiLaunchData::CONTEXT_TITLE)
-                );
-                $data->setDeliveryExecutionContext($executionContext);
+
+                $executionContext = $this->createExecutionContext($executionId, $launchData);
+                if ($executionContext instanceof DeliveryExecutionContextInterface) {
+                    $data->setDeliveryExecutionContext($executionContext);
+                }
 
                 $logData[LtiLaunchData::CONTEXT_ID] = $contextId;
                 $logData[LtiLaunchData::CONTEXT_LABEL] = $launchData->getVariable(LtiLaunchData::CONTEXT_LABEL);
@@ -227,5 +226,27 @@ class LtiListenerService extends ConfigurableService
             ARRAY_FILTER_USE_KEY
         );
         return $ltiParameters;
+    }
+
+    /**
+     * @param string $executionId
+     * @param LtiLaunchData $launchData
+     * @return DeliveryExecutionContext|null
+     */
+    private function createExecutionContext($executionId, LtiLaunchData $launchData)
+    {
+        $executionContext = null;
+        try {
+            $executionContext = new DeliveryExecutionContext(
+                $executionId,
+                $launchData->getVariable(LtiLaunchData::CONTEXT_ID),
+                LtiDeliveryExecutionContext::EXECUTION_CONTEXT_TYPE,
+                $launchData->getVariable(LtiLaunchData::CONTEXT_LABEL)
+            );
+        } catch (\InvalidArgumentException $e) {
+            $this->logInfo('Delivery execution context object can not be created. Reason: ' . $e->getMessage());
+        }
+
+        return $executionContext;
     }
 }

--- a/model/LtiListenerService.php
+++ b/model/LtiListenerService.php
@@ -21,8 +21,9 @@
 namespace oat\ltiProctoring\model;
 
 use oat\ltiProctoring\model\delivery\ProctorService;
-use oat\ltiProctoring\model\execution\LtiDeliveryExecutionService;
+use oat\ltiProctoring\model\execution\LtiDeliveryExecutionContext;
 use oat\oatbox\service\ConfigurableService;
+use oat\taoDelivery\model\execution\DeliveryExecutionContext;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionCreated;
 use oat\taoDelivery\models\classes\execution\event\DeliveryExecutionState;
@@ -31,6 +32,7 @@ use oat\taoLti\models\classes\TaoLtiSession;
 use oat\taoProctoring\model\deliveryLog\DeliveryLog;
 use oat\taoProctoring\model\execution\DeliveryExecution;
 use oat\taoProctoring\model\execution\DeliveryExecutionManagerService;
+use oat\taoProctoring\model\monitorCache\DeliveryMonitoringData;
 use oat\taoProctoring\model\monitorCache\DeliveryMonitoringService;
 use oat\taoQtiTest\models\runner\time\QtiTimer;
 use oat\taoLti\models\classes\LtiVariableMissingException;
@@ -72,6 +74,7 @@ class LtiListenerService extends ConfigurableService
             }
 
             $monitoringService = $serviceManager->get(DeliveryMonitoringService::SERVICE_ID);
+            /** @var DeliveryMonitoringData $data */
             $data = $monitoringService->getData($deliveryExecution);
 
             // tag data
@@ -84,6 +87,14 @@ class LtiListenerService extends ConfigurableService
             try {
                 $contextId = $launchData->getVariable(LtiLaunchData::CONTEXT_ID);
                 $data->update(LtiLaunchData::CONTEXT_ID, $contextId);
+                $executionContext = new DeliveryExecutionContext(
+                    $executionId,
+                    $contextId,
+                    LtiDeliveryExecutionContext::EXECUTION_CONTEXT_TYPE,
+                    $launchData->getVariable(LtiLaunchData::CONTEXT_TITLE)
+                );
+                $data->setDeliveryExecutionContext($executionContext);
+
                 $logData[LtiLaunchData::CONTEXT_ID] = $contextId;
                 $logData[LtiLaunchData::CONTEXT_LABEL] = $launchData->getVariable(LtiLaunchData::CONTEXT_LABEL);
             } catch (LtiVariableMissingException $e) {

--- a/model/execution/LtiDeliveryExecutionContext.php
+++ b/model/execution/LtiDeliveryExecutionContext.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\ltiProctoring\model\execution;
+
+use oat\taoDelivery\model\execution\DeliveryExecutionContext;
+
+class LtiDeliveryExecutionContext extends DeliveryExecutionContext
+{
+    const EXECUTION_CONTEXT_TYPE = 'lti';
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -205,6 +205,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '5.1.1');
+        $this->skip('4.0.0', '5.2.0');
     }
 }


### PR DESCRIPTION
Store delivery execution context details in delivery monitoring data on execution created event.

Requires:
https://github.com/oat-sa/extension-tao-proctoring/pull/670
https://github.com/oat-sa/extension-tao-delivery/pull/385
https://github.com/oat-sa/extension-tao-lti/pull/174