### PR TITLE
Fix/tao 8581/return empty name string when user doesnt exist

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '5.2.0',
+    'version' => '5.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',

--- a/model/implementation/TestSessionHistoryService.php
+++ b/model/implementation/TestSessionHistoryService.php
@@ -85,6 +85,9 @@ class TestSessionHistoryService extends TestSessionHistoryServiceProctoring
         /** @var LtiUserService $ltiUserService */
         $ltiUserService = $this->getServiceLocator()->get(LtiUserService::SERVICE_ID);
         $userData = $ltiUserService->getUserDataFromId($userId);
+        if ($userData === null) {
+            $userData = [];
+        }
 
         return $ltiUserService->getUserName($userData);
     }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -205,6 +205,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '5.2.0');
+        $this->skip('4.0.0', '5.2.1');
     }
 }


### PR DESCRIPTION
Issue: https://oat-sa.atlassian.net/browse/TAO-8581
For sessions terminated by CLI script there is no information about author. Because of thatrequest to open detailed session view fails. As a fix we may do not show role/username for such events and as future improvement we may create system user (similar to current super user) and use this user in cli scripts.

To test: 
1. Start delivery execution via LTI.
2. Pause execution from proctor screen.
3. Terminate execution using CLI action `taoProctoring/scripts/TerminatePausedAssessment.php`
4. Go to proctor screen and try to open detailed view for terminated session