### PR TITLE
Fix/tao 9572/check lti parameters to check secure test

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -42,7 +42,7 @@ return array(
     'requires' => array(
         'tao' => '>=21.0.0',
         'taoLti' => '>=8.6.1',
-        'taoProctoring' => '>=12.7.0',
+        'taoProctoring' => '>=18.2.2',
         'taoDelivery' => '>=12.5.0',
         'ltiDeliveryProvider' => '>=7.0.0',
     ),

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '5.2.1',
+    'version' => '5.2.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',
-        'taoLti' => '>=8.6.1',
+        'taoLti' => '>=11.3.0',
         'taoProctoring' => '>=18.2.2',
         'taoDelivery' => '>=12.5.0',
         'ltiDeliveryProvider' => '>=7.0.0',

--- a/model/delivery/LtiTestTakerAuthorizationService.php
+++ b/model/delivery/LtiTestTakerAuthorizationService.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -17,6 +18,7 @@
  * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
  *
  */
+
 namespace oat\ltiProctoring\model\delivery;
 
 use common_session_Session;
@@ -32,6 +34,7 @@ use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\oatbox\user\User;
 use oat\taoProctoring\model\DelegatedServiceHandler;
 use oat\taoLti\models\classes\LtiRoles;
+
 /**
  * Manage the Delivery authorization.
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
@@ -61,7 +64,7 @@ class LtiTestTakerAuthorizationService extends TestTakerAuthorizationService imp
                 $var = mb_strtolower($launchData->getVariable(self::CUSTOM_LTI_PROCTORED));
                 if ($var !== 'true' && $var !== 'false') {
                     throw new LtiException(
-                        'Wrong value of `'.self::CUSTOM_LTI_PROCTORED.'` variable.',
+                        'Wrong value of `' . self::CUSTOM_LTI_PROCTORED . '` variable.',
                         LtiErrorMessage::ERROR_INVALID_PARAMETER
                     );
                 }

--- a/model/delivery/LtiTestTakerAuthorizationService.php
+++ b/model/delivery/LtiTestTakerAuthorizationService.php
@@ -20,6 +20,7 @@
 namespace oat\ltiProctoring\model\delivery;
 
 use common_session_Session;
+use oat\ltiDeliveryProvider\model\delivery\DeliveryContainerService;
 use oat\oatbox\session\SessionService;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiLaunchData;
@@ -69,6 +70,26 @@ class LtiTestTakerAuthorizationService extends TestTakerAuthorizationService imp
         }
         return $proctored;
     }
+
+    /**
+     * @param string $deliveryId
+     * @return bool
+     * @throws \common_Exception
+     */
+    protected function isSecure($deliveryId)
+    {
+        $secureTest = parent::isSecure($deliveryId);
+        $currentSession = $this->getSession();
+        if ($currentSession instanceof TaoLtiSession) {
+            $launchData = $currentSession->getLaunchData();
+            if ($launchData->hasVariable(DeliveryContainerService::CUSTOM_LTI_SECURE)) {
+                $secureTest = $launchData->getVariable(DeliveryContainerService::CUSTOM_LTI_SECURE) === 'true';
+            }
+        }
+
+        return $secureTest;
+    }
+
 
     /**
      * @return common_session_Session

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -205,6 +205,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('4.0.0');
         }
 
-        $this->skip('4.0.0', '5.2.1');
+        $this->skip('4.0.0', '5.2.2');
     }
 }

--- a/test/unit/model/delivery/LtiTestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/delivery/LtiTestTakerAuthorizationServiceTest.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace oat\ltiProctoring\test\unit\model\delivery;
+
+use common_session_Session;
+use core_kernel_classes_Resource;
+use core_kernel_classes_Property;
+use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
+use oat\generis\model\data\Ontology;
+use oat\ltiProctoring\model\delivery\LtiTestTakerAuthorizationService;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
+use oat\taoLti\models\classes\LtiException;
+use oat\taoLti\models\classes\LtiInvalidVariableException;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoLti\models\classes\TaoLtiSession;
+
+class LtiTestTakerAuthorizationServiceTest extends TestCase
+{
+    private $object;
+
+    /**
+     * @var Ontology|MockObject
+     */
+    private $ontologyMock;
+
+    /**
+     * @var core_kernel_classes_Resource|MockObject
+     */
+    private $deliveryResourceMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->deliveryResourceMock = $this->createMock(core_kernel_classes_Resource::class);
+        $this->ontologyMock = $this->createMock(Ontology::class);
+
+        $this->object = new LtiTestTakerAuthorizationService();
+    }
+
+    /**
+     * @param string $proctoredPropertyUriValue
+     * @param string $sessionType
+     * @param bool $ltiVarExists
+     * @param bool $ltiVarValue
+     * @param bool $expectedResult
+     *
+     * @dataProvider dataProviderTestIsProctored
+     *
+     * @throws \oat\taoLti\models\classes\LtiException
+     * @throws \oat\taoLti\models\classes\LtiVariableMissingException
+     */
+    public function testIsProctored($proctoredPropertyUriValue, $sessionType, $ltiVarExists, $ltiVarValue, $expectedResult)
+    {
+        $deliveryUri = 'FAKE_DELIVERY_URI';
+        $user = $this->createMock(User::class);
+
+        $this->mockParentIsProctoredBehavior($proctoredPropertyUriValue);
+
+        // Test LTI parameters functionality
+        $ltiVarName = 'custom_proctored';
+        $launchDataMock = $this->getLtiLaunchDataMock($ltiVarName, $ltiVarExists, $ltiVarValue);
+        $sessionServiceMock = $this->getSessionServiceMock($sessionType, $launchDataMock);
+
+        $slMock = $this->getServiceLocatorMock([
+            Ontology::SERVICE_ID => $this->ontologyMock,
+            SessionService::SERVICE_ID => $sessionServiceMock,
+        ]);
+        $this->object->setServiceLocator($slMock);
+        $result = $this->object->isProctored($deliveryUri, $user);
+
+        $this->assertEquals($expectedResult, $result, 'Result of isProctored() check must be as expected.');
+    }
+
+    public function testIsProctoredInvalidLtiVariableThrowsException()
+    {
+        $deliveryUri = 'FAKE_DELIVERY_URI';
+        $user = $this->createMock(User::class);
+
+        $this->mockParentIsProctoredBehavior("DUMMY_PROPERTY_VALUE");
+
+        $ltiVarName = 'custom_proctored';
+        $launchDataMock = $this->createMock(LtiLaunchData::class);
+        $launchDataMock->method('hasVariable')
+            ->with($ltiVarName)
+            ->willReturn(true);
+        $launchDataMock->method('getBooleanVariable')
+            ->willThrowException(new LtiInvalidVariableException("Exception message"));
+
+        $sessionServiceMock = $this->getSessionServiceMock(TaoLtiSession::class, $launchDataMock);
+
+        $slMock = $this->getServiceLocatorMock([
+            Ontology::SERVICE_ID => $this->ontologyMock,
+            SessionService::SERVICE_ID => $sessionServiceMock,
+        ]);
+        $this->object->setServiceLocator($slMock);
+
+        $this->expectException(LtiException::class);
+
+        $this->object->isProctored($deliveryUri, $user);
+    }
+
+    /**
+     * @param string $testRunnerFeatures
+     * @param string $sessionType
+     * @param bool $ltiVarExists
+     * @param bool $ltiVarValue
+     * @param bool $expectedResult
+     *
+     * @dataProvider dataProviderTestIsSecure
+     *
+     * @throws LtiException
+     * @throws \common_Exception
+     */
+    public function testIsSecure($testRunnerFeatures, $sessionType, $ltiVarExists, $ltiVarValue, $expectedResult)
+    {
+        $deliveryId = 'FAKE_DELIVERY_ID';
+
+        $this->mockParentIsSecureBehavior($testRunnerFeatures);
+
+        $ltiVarName = 'custom_secure';
+        $launchDataMock = $this->getLtiLaunchDataMock($ltiVarName, $ltiVarExists, $ltiVarValue);
+        $sessionServiceMock = $this->getSessionServiceMock($sessionType, $launchDataMock);
+
+        $serviceLocatorMock = $this->getServiceLocatorMock([
+            Ontology::SERVICE_ID => $this->ontologyMock,
+            SessionService::SERVICE_ID => $sessionServiceMock
+        ]);
+        $this->object->setServiceLocator($serviceLocatorMock);
+
+        $result = $this->object->isSecure($deliveryId);
+        $this->assertEquals($expectedResult, $result, 'Result of isSecure() check must be as expected.');
+    }
+
+    public function testIsSecureInvalidLtiVariableThrowsException()
+    {
+        $deliveryId = 'FAKE_DELIVERY_ID';
+
+        $this->mockParentIsSecureBehavior("FAKE_TEST_RUNNER_FEATURES");
+
+        $ltiVarName = 'custom_secure';
+        $launchDataMock = $this->createMock(LtiLaunchData::class);
+        $launchDataMock->method('hasVariable')
+            ->with($ltiVarName)
+            ->willReturn(true);
+        $launchDataMock->method('getBooleanVariable')
+            ->willThrowException(new LtiInvalidVariableException("Exception message"));
+
+        $sessionServiceMock = $this->getSessionServiceMock(TaoLtiSession::class, $launchDataMock);
+
+        $serviceLocatorMock = $this->getServiceLocatorMock([
+            Ontology::SERVICE_ID => $this->ontologyMock,
+            SessionService::SERVICE_ID => $sessionServiceMock
+        ]);
+        $this->object->setServiceLocator($serviceLocatorMock);
+
+        $this->expectException(LtiException::class);
+        $this->object->isSecure($deliveryId);
+    }
+
+    public function dataProviderTestIsProctored()
+    {
+        return [
+            'Not LTI session, parent - proctored' => [
+                'proctoredPropertyUriValue' => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled',
+                'sessionType' => common_session_Session::class,
+                'ltiVarExists' => 'NOT_IMPORTANT',
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => true,
+            ],
+            'Not LTI session, parent - not proctored' => [
+                'proctoredPropertyUriValue' => 'NOT_PROCTORED_URI_VALUE',
+                'sessionType' => common_session_Session::class,
+                'ltiVarExists' => 'NOT_IMPORTANT',
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => false,
+            ],
+            'LTI session, parent - proctored, lti variable does not exists' => [
+                'proctoredPropertyUriValue' => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => false,
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - not proctored, lti variable does not exists' => [
+                'proctoredPropertyUriValue' => 'NOT_PROCTORED_URI_VALUE',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => false,
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => false,
+            ],
+            'LTI session, parent - proctored, lti variable exists, lti var value - true' => [
+                'proctoredPropertyUriValue' => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => true,
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - not proctored, lti variable exists, lti var value - true' => [
+                'proctoredPropertyUriValue' => 'NOT_PROCTORED_URI_VALUE',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => true,
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - proctored, lti variable exists, lti var value - false' => [
+                'proctoredPropertyUriValue' => 'http://www.tao.lu/Ontologies/TAODelivery.rdf#ComplyEnabled',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => false,
+                'expectedResult' => false,
+            ],
+        ];
+    }
+
+    public function dataProviderTestIsSecure()
+    {
+        return [
+            'Not LTI session, parent - secure' => [
+                'testRunnerFeatures' => 'security',
+                'sessionType' => common_session_Session::class,
+                'ltiVarExists' => 'NOT_IMPORTANT',
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => true,
+            ],
+            'Not LTI session, parent - not secure' => [
+                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
+                'sessionType' => common_session_Session::class,
+                'ltiVarExists' => 'NOT_IMPORTANT',
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => false,
+            ],
+            'LTI session, parent - secure, lti variable does not exists' => [
+                'testRunnerFeatures' => 'security',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => false,
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - not secure, lti variable does not exists' => [
+                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => false,
+                'ltiVarValue' => 'NOT_IMPORTANT',
+                'expectedResult' => false,
+            ],
+            'LTI session, parent - secure, lti variable exists, lti var value - true' => [
+                'testRunnerFeatures' => 'security',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => true,
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - not secure secure, lti variable exists, lti var value - true' => [
+                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => true,
+                'expectedResult' => true,
+            ],
+            'LTI session, parent - secure, lti variable exists, lti var value - false' => [
+                'testRunnerFeatures' => 'security',
+                'sessionType' => TaoLtiSession::class,
+                'ltiVarExists' => true,
+                'ltiVarValue' => false,
+                'expectedResult' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param string $proctoredPropertyUriValue
+     */
+    private function mockParentIsProctoredBehavior($proctoredPropertyUriValue)
+    {
+        $proctoredPropertyMock = $this->createMock(core_kernel_classes_Property::class);
+        $proctoredPropertyMock->method('getUri')->willReturn($proctoredPropertyUriValue);
+
+        $this->deliveryResourceMock->method('getOnePropertyValue')->willReturn($proctoredPropertyMock);
+
+        $this->ontologyMock->method('getResource')->willReturn($this->deliveryResourceMock);
+        $this->ontologyMock->method('getProperty')->willReturn(new core_kernel_classes_Property('FAKE_PROPERTY'));
+    }
+
+    /**
+     * @param string $testRunnerFeatures
+     */
+    private function mockParentIsSecureBehavior($testRunnerFeatures)
+    {
+        $this->deliveryResourceMock->method('getOnePropertyValue')->willReturn($testRunnerFeatures);
+
+        $this->ontologyMock->method('getResource')->willReturn($this->deliveryResourceMock);
+        $this->ontologyMock->method('getProperty')->willReturn(new core_kernel_classes_Property('FAKE_PROPERTY'));
+    }
+
+    /**
+     * @param $sessionType
+     * @param MockObject $launchDataMock
+     * @return MockObject
+     */
+    private function getSessionServiceMock($sessionType, LtiLaunchData $launchDataMock)
+    {
+        $currentSessionMock = $this->createMock($sessionType);
+        $currentSessionMock->method('getLaunchData')->willReturn($launchDataMock);
+
+        $sessionServiceMock = $this->createMock(SessionService::class);
+        $sessionServiceMock->method('getCurrentSession')->willReturn($currentSessionMock);
+
+        return $sessionServiceMock;
+    }
+
+    /**
+     * @param $ltiVarExists
+     * @param $ltiVarValue
+     * @param string $ltiVarName
+     * @return MockObject
+     */
+    private function getLtiLaunchDataMock($ltiVarName, $ltiVarExists, $ltiVarValue)
+    {
+        $launchDataMock = $this->createMock(LtiLaunchData::class);
+        $launchDataMock->method('hasVariable')
+            ->with($ltiVarName)
+            ->willReturn($ltiVarExists);
+        $launchDataMock->method('getBooleanVariable')->willReturn($ltiVarValue);
+
+        return $launchDataMock;
+    }
+}


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TAO-9572

Depends on:
- https://github.com/oat-sa/extension-tao-lti/pull/225
- https://github.com/oat-sa/extension-tao-proctoring/pull/760

The goal of this PR is to fix bug while checking if test taker is authorized to resume a test (when `proctored` and/or `secure` properties are redefined via LTI custom parameters).
To test:
- create a delivery with proctored=enabled, secure=enabled
- launch LTI delivery execution with different combinations of proctored and secure custom parameters: `proctored=false,secure=false`, `proctored=true,secure=false`, `proctored=false,secure=true`, `proctored=true,secure=true`
- when delivery execution is started/authorized try to reload page in browser

