### PR TITLE
Feature/actp 282/decide if delivery is secure based on plugin

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '7.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'tao' => '>=21.0.0',

--- a/model/delivery/LtiTestTakerAuthorizationService.php
+++ b/model/delivery/LtiTestTakerAuthorizationService.php
@@ -22,7 +22,6 @@
 namespace oat\ltiProctoring\model\delivery;
 
 use common_session_Session;
-use oat\ltiDeliveryProvider\model\delivery\DeliveryContainerService;
 use oat\oatbox\session\SessionService;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\LtiInvalidVariableException;
@@ -31,7 +30,6 @@ use oat\taoLti\models\classes\TaoLtiSession;
 use oat\taoProctoring\model\authorization\TestTakerAuthorizationService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\authorization\UnAuthorizedException;
-use oat\taoLti\models\classes\LtiMessages\LtiErrorMessage;
 use oat\oatbox\user\User;
 use oat\taoProctoring\model\DelegatedServiceHandler;
 use oat\taoLti\models\classes\LtiRoles;
@@ -72,32 +70,6 @@ class LtiTestTakerAuthorizationService extends TestTakerAuthorizationService imp
             throw new LtiException($e->getMessage(), $e->getCode());
         }
     }
-
-    /**
-     * @param string $deliveryId
-     * @return bool
-     *
-     * @throws LtiException
-     * @throws \common_Exception
-     */
-    public function isSecure($deliveryId)
-    {
-        try {
-            $secureTest = parent::isSecure($deliveryId);
-            $currentSession = $this->getSession();
-            if ($currentSession instanceof TaoLtiSession) {
-                $launchData = $currentSession->getLaunchData();
-                if ($launchData->hasVariable(DeliveryContainerService::CUSTOM_LTI_SECURE)) {
-                    $secureTest = $launchData->getBooleanVariable(DeliveryContainerService::CUSTOM_LTI_SECURE);
-                }
-            }
-
-            return $secureTest;
-        } catch (LtiInvalidVariableException $e) {
-            throw new LtiException($e->getMessage(), $e->getCode());
-        }
-    }
-
 
     /**
      * @return common_session_Session

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -213,7 +213,7 @@ class Updater extends \common_ext_ExtensionUpdater
                 LtiMonitorParametersService::SERVICE_ID,
                 new LtiMonitorParametersService()
             );
-            $this->setVersion('6.1.0');
+            $this->setVersion('7.0.0');
         }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -213,7 +213,9 @@ class Updater extends \common_ext_ExtensionUpdater
                 LtiMonitorParametersService::SERVICE_ID,
                 new LtiMonitorParametersService()
             );
-            $this->setVersion('7.0.0');
+            $this->setVersion('6.1.0');
         }
+
+        $this->skip('6.1.0', '7.0.0');
     }
 }

--- a/test/unit/model/delivery/LtiTestTakerAuthorizationServiceTest.php
+++ b/test/unit/model/delivery/LtiTestTakerAuthorizationServiceTest.php
@@ -101,64 +101,6 @@ class LtiTestTakerAuthorizationServiceTest extends TestCase
         $this->object->isProctored($deliveryUri, $user);
     }
 
-    /**
-     * @param string $testRunnerFeatures
-     * @param string $sessionType
-     * @param bool $ltiVarExists
-     * @param bool $ltiVarValue
-     * @param bool $expectedResult
-     *
-     * @dataProvider dataProviderTestIsSecure
-     *
-     * @throws LtiException
-     * @throws \common_Exception
-     */
-    public function testIsSecure($testRunnerFeatures, $sessionType, $ltiVarExists, $ltiVarValue, $expectedResult)
-    {
-        $deliveryId = 'FAKE_DELIVERY_ID';
-
-        $this->mockParentIsSecureBehavior($testRunnerFeatures);
-
-        $ltiVarName = 'custom_secure';
-        $launchDataMock = $this->getLtiLaunchDataMock($ltiVarName, $ltiVarExists, $ltiVarValue);
-        $sessionServiceMock = $this->getSessionServiceMock($sessionType, $launchDataMock);
-
-        $serviceLocatorMock = $this->getServiceLocatorMock([
-            Ontology::SERVICE_ID => $this->ontologyMock,
-            SessionService::SERVICE_ID => $sessionServiceMock
-        ]);
-        $this->object->setServiceLocator($serviceLocatorMock);
-
-        $result = $this->object->isSecure($deliveryId);
-        $this->assertEquals($expectedResult, $result, 'Result of isSecure() check must be as expected.');
-    }
-
-    public function testIsSecureInvalidLtiVariableThrowsException()
-    {
-        $deliveryId = 'FAKE_DELIVERY_ID';
-
-        $this->mockParentIsSecureBehavior("FAKE_TEST_RUNNER_FEATURES");
-
-        $ltiVarName = 'custom_secure';
-        $launchDataMock = $this->createMock(LtiLaunchData::class);
-        $launchDataMock->method('hasVariable')
-            ->with($ltiVarName)
-            ->willReturn(true);
-        $launchDataMock->method('getBooleanVariable')
-            ->willThrowException(new LtiInvalidVariableException("Exception message"));
-
-        $sessionServiceMock = $this->getSessionServiceMock(TaoLtiSession::class, $launchDataMock);
-
-        $serviceLocatorMock = $this->getServiceLocatorMock([
-            Ontology::SERVICE_ID => $this->ontologyMock,
-            SessionService::SERVICE_ID => $sessionServiceMock
-        ]);
-        $this->object->setServiceLocator($serviceLocatorMock);
-
-        $this->expectException(LtiException::class);
-        $this->object->isSecure($deliveryId);
-    }
-
     public function dataProviderTestIsProctored()
     {
         return [
@@ -214,61 +156,6 @@ class LtiTestTakerAuthorizationServiceTest extends TestCase
         ];
     }
 
-    public function dataProviderTestIsSecure()
-    {
-        return [
-            'Not LTI session, parent - secure' => [
-                'testRunnerFeatures' => 'security',
-                'sessionType' => common_session_Session::class,
-                'ltiVarExists' => 'NOT_IMPORTANT',
-                'ltiVarValue' => 'NOT_IMPORTANT',
-                'expectedResult' => true,
-            ],
-            'Not LTI session, parent - not secure' => [
-                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
-                'sessionType' => common_session_Session::class,
-                'ltiVarExists' => 'NOT_IMPORTANT',
-                'ltiVarValue' => 'NOT_IMPORTANT',
-                'expectedResult' => false,
-            ],
-            'LTI session, parent - secure, lti variable does not exists' => [
-                'testRunnerFeatures' => 'security',
-                'sessionType' => TaoLtiSession::class,
-                'ltiVarExists' => false,
-                'ltiVarValue' => 'NOT_IMPORTANT',
-                'expectedResult' => true,
-            ],
-            'LTI session, parent - not secure, lti variable does not exists' => [
-                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
-                'sessionType' => TaoLtiSession::class,
-                'ltiVarExists' => false,
-                'ltiVarValue' => 'NOT_IMPORTANT',
-                'expectedResult' => false,
-            ],
-            'LTI session, parent - secure, lti variable exists, lti var value - true' => [
-                'testRunnerFeatures' => 'security',
-                'sessionType' => TaoLtiSession::class,
-                'ltiVarExists' => true,
-                'ltiVarValue' => true,
-                'expectedResult' => true,
-            ],
-            'LTI session, parent - not secure secure, lti variable exists, lti var value - true' => [
-                'testRunnerFeatures' => 'NO_SECURITY_VALUE',
-                'sessionType' => TaoLtiSession::class,
-                'ltiVarExists' => true,
-                'ltiVarValue' => true,
-                'expectedResult' => true,
-            ],
-            'LTI session, parent - secure, lti variable exists, lti var value - false' => [
-                'testRunnerFeatures' => 'security',
-                'sessionType' => TaoLtiSession::class,
-                'ltiVarExists' => true,
-                'ltiVarValue' => false,
-                'expectedResult' => false,
-            ],
-        ];
-    }
-
     /**
      * @param string $proctoredPropertyUriValue
      */
@@ -278,17 +165,6 @@ class LtiTestTakerAuthorizationServiceTest extends TestCase
         $proctoredPropertyMock->method('getUri')->willReturn($proctoredPropertyUriValue);
 
         $this->deliveryResourceMock->method('getOnePropertyValue')->willReturn($proctoredPropertyMock);
-
-        $this->ontologyMock->method('getResource')->willReturn($this->deliveryResourceMock);
-        $this->ontologyMock->method('getProperty')->willReturn(new core_kernel_classes_Property('FAKE_PROPERTY'));
-    }
-
-    /**
-     * @param string $testRunnerFeatures
-     */
-    private function mockParentIsSecureBehavior($testRunnerFeatures)
-    {
-        $this->deliveryResourceMock->method('getOnePropertyValue')->willReturn($testRunnerFeatures);
 
         $this->ontologyMock->method('getResource')->willReturn($this->deliveryResourceMock);
         $this->ontologyMock->method('getProperty')->willReturn(new core_kernel_classes_Property('FAKE_PROPERTY'));


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-282

The goal of this PR is to remove method `isSecure` which checks if delivery execution is in secure mode taking into account LTI parameter `custom_secure`. This functionality will be covered by parent class and DeliveryContainerService based on list of enabled plugins. Only `blurPause` plugin is used to check if delivery execution should be paused when focus is lost in test runner.