### PR TITLE
Fix/actp 291/correct number of queued users on assessment activity screen

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -41,7 +41,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.15.0',
-        'tao' => '>=41.4.0',
+        'tao' => '>=41.9.0',
         'taoLti' => '>=11.3.0',
         'taoProctoring' => '>=18.2.2',
         'taoDelivery' => '>=12.5.0',

--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '7.2.0',
+    'version' => '8.0.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.15.0',

--- a/manifest.php
+++ b/manifest.php
@@ -37,11 +37,11 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '7.1.0',
+    'version' => '7.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.15.0',
-        'tao' => '>=21.0.0',
+        'tao' => '>=41.4.0',
         'taoLti' => '>=11.3.0',
         'taoProctoring' => '>=18.2.2',
         'taoDelivery' => '>=12.5.0',

--- a/model/ActivityMonitoringService.php
+++ b/model/ActivityMonitoringService.php
@@ -66,9 +66,10 @@ class ActivityMonitoringService extends BaseActivityMonitoringService
         $actionQueue = $this->getServiceLocator()->get(ActionQueue::SERVICE_ID);
         $activeDeliveryExecution = new GetActiveDeliveryExecution();
 
-        $queue = __('Turned off');
         if ($actionQueue->isActionEnabled($activeDeliveryExecution)) {
             $queue = $actionQueue->getPosition($activeDeliveryExecution);
+        } else {
+            $queue = __('Turned off');
         }
 
         return $queue;

--- a/model/ActivityMonitoringService.php
+++ b/model/ActivityMonitoringService.php
@@ -67,8 +67,7 @@ class ActivityMonitoringService extends BaseActivityMonitoringService
         $activeDeliveryExecution = new GetActiveDeliveryExecution();
 
         $queue = __('Turned off');
-        $limit = $actionQueue->getLimits($activeDeliveryExecution);
-        if ($limit > 0) {
+        if ($actionQueue->isActionEnabled($activeDeliveryExecution)) {
             $queue = $actionQueue->getPosition($activeDeliveryExecution);
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -216,6 +216,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.2.0');
+        $this->skip('6.1.0', '8.0.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -216,6 +216,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '7.1.0');
+        $this->skip('6.1.0', '7.2.0');
     }
 }


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-291

Requires: https://github.com/oat-sa/tao-core/pull/2445

**Problem:** 
`Tools -> Assessment Activity` screen shows incorrect number of users in the Login Queue at the moment.

**Solution:** 
Use the new method in InstantActionQueue::isActionEnabled() to check if Login Queue is enabled.

**How to test:** 
- configure Login Queue to redirect users to queue - config/tao/ActionQueue.conf.php
- launch delivery execution via LTI and wait for user to be redirected to Login Queue
- in new tab login as user with Operational Administrator role
- go to Tools -> Assessment Activity. In `Queued test-takers` block you should see 1 user in queue
