### PR TITLE
Feature/actp 342/Exclude kv_delivery_monitoring columns for performance improvements

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -45,7 +45,7 @@ return array(
         'generis' => '>=12.15.0',
         'tao' => '>=41.9.0',
         'taoLti' => '>=11.3.0',
-        'taoProctoring' => '>=18.2.2',
+        'taoProctoring' => '>=19.4.0',
         'taoDelivery' => '>=12.5.0',
         'ltiDeliveryProvider' => '>=7.0.0',
         'taoOutcomeUi' => '>=7.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -28,6 +28,8 @@ use oat\ltiProctoring\scripts\install\SetupProctoringEventListeners;
 use oat\ltiProctoring\scripts\install\RegisterServices;
 use oat\ltiProctoring\controller\DeliveryServer;
 use oat\ltiProctoring\scripts\install\SetupTestSessionHistory;
+use oat\ltiProctoring\scripts\install\AlterDeliveryMonitoringTable;
+use oat\ltiProctoring\scripts\install\OverrideProctorService;
 
 /**
  * Generated using taoDevTools 2.17.0
@@ -37,7 +39,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '8.0.0',
+    'version' => '8.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.15.0',
@@ -68,7 +70,8 @@ return array(
             RegisterServices::class,
             SetupTestSessionHistory::class,
             SetupTestRunnerMessageService::class,
-            \oat\ltiProctoring\scripts\install\OverrideProctorService::class,
+            OverrideProctorService::class,
+            AlterDeliveryMonitoringTable::class
         ],
         'rdf' => array(
             __DIR__.DIRECTORY_SEPARATOR.'scripts'.DIRECTORY_SEPARATOR.'install'.DIRECTORY_SEPARATOR.'ltiroles.rdf'

--- a/model/delivery/ProctorService.php
+++ b/model/delivery/ProctorService.php
@@ -85,7 +85,7 @@ class ProctorService extends DefaultProctorService
             }
         }
         $options['asArray'] = true;
-        return $monitoringService->find($criteria, $options, true);
+        return $monitoringService->find($criteria, $options, false);
     }
 
     /**

--- a/scripts/install/AlterDeliveryMonitoringTable.php
+++ b/scripts/install/AlterDeliveryMonitoringTable.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiProctoring\scripts\install;
+
+use common_Exception;
+use common_report_Report as Report;
+use oat\ltiProctoring\scripts\install\db\DeliveryMonitoringDbMigration;
+use oat\oatbox\extension\InstallAction;
+use oat\taoProctoring\model\monitorCache\implementation\MonitorCacheService;
+use oat\taoProctoring\scripts\install\db\DbSetup;
+
+class AlterDeliveryMonitoringTable extends InstallAction
+{
+    /**
+     * @param $params
+     * @return Report
+     * @throws \common_exception_Error
+     */
+    public function __invoke($params): Report
+    {
+        $report = Report::createInfo("Start delivery monitoring table migration.");
+        try {
+            $monitoringCacheService = $this->getServiceManager()->get(MonitorCacheService::SERVICE_ID);
+            $persistence = $monitoringCacheService->getPersistence();
+
+            $dbMigration = new DeliveryMonitoringDbMigration();
+            $dbMigration->alterTable($persistence);
+
+            $newPrimaryColumns = array_unique(array_merge(DbSetup::getPrimaryColumns(),$dbMigration->getExtraColumns()));
+            $monitoringCacheService->setOption(MonitorCacheService::OPTION_PRIMARY_COLUMNS, $newPrimaryColumns);
+
+            $this->registerService(MonitorCacheService::SERVICE_ID, $monitoringCacheService);
+            $report->add(Report::createSuccess("Migration successfully executed."));
+        } catch (common_Exception $exception) {
+            $report->add(Report::createFailure("Error during migration: " . $exception->getMessage()));
+        }
+
+        return $report;
+    }
+}

--- a/scripts/install/db/DeliveryMonitoringDbMigration.php
+++ b/scripts/install/db/DeliveryMonitoringDbMigration.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+declare(strict_types=1);
+
+namespace oat\ltiProctoring\scripts\install\db;
+
+use common_Exception;
+use common_Logger;
+use common_persistence_SqlPersistence;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use Doctrine\DBAL\Schema\Table;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoProctoring\model\monitorCache\implementation\MonitoringStorage;
+
+class DeliveryMonitoringDbMigration
+{
+    /**
+     * @param common_persistence_SqlPersistence $persistence
+     */
+    public function alterTable(common_persistence_SqlPersistence $persistence): void
+    {
+        $schemaManager = $persistence->getDriver()->getSchemaManager();
+        /** @var Schema $schema */
+        $schema = $schemaManager->createSchema();
+
+        /** @var Schema $fromSchema */
+        $fromSchema = clone $schema;
+        try {
+            /** @var Table $table */
+            $table = $schema->getTable(MonitoringStorage::TABLE_NAME);
+            if ($table->hasColumn(LtiLaunchData::CONTEXT_ID)) {
+                common_Logger::i(
+                    sprintf(
+                        'Column `%s` already exists in `%s` table.',
+                        LtiLaunchData::CONTEXT_ID,
+                        MonitoringStorage::TABLE_NAME
+                    )
+                );
+                return;
+            }
+
+            $table->addColumn(LtiLaunchData::CONTEXT_ID, "string", array("notnull" => false, "length" => 255));
+            $queries = $persistence->getPlatForm()->getMigrateSchemaSql($fromSchema, $schema);
+            foreach ($queries as $query) {
+                $persistence->exec($query);
+            }
+        } catch(SchemaException $e) {
+            common_Logger::i('Database Schema already up to date.');
+        } catch (common_Exception $e) {
+            common_Logger::e($e->getMessage());
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function getExtraColumns(): array
+    {
+        return [LtiLaunchData::CONTEXT_ID];
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -217,5 +217,12 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         $this->skip('6.1.0', '8.0.0');
+
+        if ($this->isVersion('8.0.0')) {
+            $script = 'sudo -u www-data php index.php \'oat\taoProctoring\scripts\tools\KvMonitoringMigration\' -f context_id -d 1 -s 0 -pc';
+            $this->addReport(\common_report_Report::createInfo("Run script :'" . $script . "' to finish updating. It may take few hours depending of amount of data."));
+
+            $this->setVersion('8.1.0');
+        }
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -246,7 +246,7 @@ class Updater extends \common_ext_ExtensionUpdater
         }
 
         if ($this->isVersion('8.1.0')) {
-            $script = 'sudo -u www-data php index.php \'oat\taoProctoring\scripts\tools\KvMonitoringMigration\' -f context_id -d 1 -s 0 -pc';
+            $script = 'sudo -u www-data php index.php \'oat\taoProctoring\scripts\tools\KvMonitoringMigration\' -f context_id -d 1 -s 0 -pc -l 255';
             $this->addReport(\common_report_Report::createInfo("Run script :'" . $script . "' to finish updating. It may take few hours depending of amount of data."));
 
             $this->setVersion('8.2.0');


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/ACTP-342

The goal of this development is to improve performance on proctoring screen. For that reason we move some `context_id` column to main `delivery_monitoring` table. With this change it won't be necessary to JOIN `kv_delievry_monitoring` table to get sessions for proctor screen. 

**How to test:**
- Fresh install - `context_id` column should be present in delivery_monitoring table. 
- Update - `context_id` column created in `delivery_monitoring` table and all existing records for this key migrated to `delivery_monitoring`. Config `config/taoProctoring/DeliveryMonitoring.conf.php` is updated with new `context_id` column.

In both cases `kv_delivery_monitoring` is not used to get data for proctor screen.