### PR TITLE
test runner uses correct return url on the terminated delivery execution

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -21,7 +21,12 @@
 
 namespace oat\ltiProctoring\controller;
 
+use common_Exception;
+use common_exception_Error;
+use common_exception_NotFound;
+use common_exception_Unauthorized;
 use oat\tao\helpers\UrlHelper;
+use oat\taoDelivery\model\authorization\UnAuthorizedException;
 use oat\taoProctoring\controller\DeliveryServer as ProctoringDeliveryServer;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoProctoring\model\execution\DeliveryExecution as ProctoredDeliveryExecution;
@@ -53,6 +58,36 @@ class DeliveryServer extends ProctoringDeliveryServer
         }
         $deliveryExecution = $this->getCurrentDeliveryExecution();
         $this->setData('cancelUrl', _url('cancelExecution', 'DeliveryServer', 'ltiProctoring', ['deliveryExecution' => $deliveryExecution->getIdentifier()]));
+    }
+
+    /**
+     * @throws LtiException
+     * @throws common_Exception
+     * @throws common_exception_Error
+     * @throws common_exception_NotFound
+     * @throws common_exception_Unauthorized
+     */
+    public function runDeliveryExecution()
+    {
+        $deliveryExecution = $this->getCurrentDeliveryExecution();
+
+        // Sets the deliveryId to session.
+        if (!$this->hasSessionAttribute(DeliveryExecution::getDeliveryIdSessionKey($deliveryExecution->getIdentifier()))) {
+            $this->setSessionAttribute(
+                DeliveryExecution::getDeliveryIdSessionKey($deliveryExecution->getIdentifier()),
+                $deliveryExecution->getDelivery()->getUri()
+            );
+        }
+
+        try {
+            $this->verifyDeliveryExecutionAuthorized($deliveryExecution);
+
+            parent::runDeliveryExecution();
+        } catch (UnAuthorizedException $e) {
+            // for the lti - correct lti error (link with error message)
+            $redirectUrl = $this->getServiceLocator()->get(LTIDeliveryTool::class)->getFinishUrl($deliveryExecution);
+            $this->redirect($redirectUrl);
+        }
     }
 
     /**

--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -25,6 +25,7 @@ use common_Exception;
 use common_exception_Error;
 use common_exception_NotFound;
 use common_exception_Unauthorized;
+use InterruptedActionException;
 use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\authorization\UnAuthorizedException;
 use oat\taoProctoring\controller\DeliveryServer as ProctoringDeliveryServer;
@@ -64,14 +65,12 @@ class DeliveryServer extends ProctoringDeliveryServer
      * @throws LtiException
      * @throws common_Exception
      * @throws common_exception_Error
-     * @throws common_exception_NotFound
-     * @throws common_exception_Unauthorized
+     * @throws common_exception_NotFound|InterruptedActionException
      */
     public function runDeliveryExecution()
     {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
 
-        // Sets the deliveryId to session.
         if (!$this->hasSessionAttribute(DeliveryExecution::getDeliveryIdSessionKey($deliveryExecution->getIdentifier()))) {
             $this->setSessionAttribute(
                 DeliveryExecution::getDeliveryIdSessionKey($deliveryExecution->getIdentifier()),

--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'label' => 'LTI Proctoring',
     'description' => 'Grants access to the proctoring functionalities using LTI',
     'license' => 'GPL-2.0',
-    'version' => '9.1.0',
+    'version' => '9.1.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
         'generis' => '>=12.15.0',


### PR DESCRIPTION
Pull request summary
 
Related to: https://oat-sa.atlassian.net/browse/TCA-707
 
When terminated delivery execution run with LTI - it should redirect to the LTI error page with error in the GET params
 
#### Steps to reproduce  (for bugs)
 - we need terminated delivery execution uri
 - run terminated delivery execution (example: http://tao.loc/ltiProctoring/DeliveryServer/runDeliveryExecution?deliveryExecution=http%3A%2F%2Fsample%2Fact.rdf%23i5f0c40256e8fe354202dd5f4217aff50f2)
- you'll be redirected to the list of the tests without any message
  
#### How to test
 
- run terminated DE
- you will be redirected to the LTI with correct URL