### PR TITLE
Feature/pr 497/do not rewrite execution context if exists

### DIFF
--- a/controller/DeliveryServer.php
+++ b/controller/DeliveryServer.php
@@ -67,7 +67,7 @@ class DeliveryServer extends ProctoringDeliveryServer
      * @throws common_exception_Error
      * @throws common_exception_NotFound|InterruptedActionException
      */
-    public function runDeliveryExecution()
+    public function runDeliveryExecution(): void
     {
         $deliveryExecution = $this->getCurrentDeliveryExecution();
 

--- a/model/LtiLaunchDataService.php
+++ b/model/LtiLaunchDataService.php
@@ -27,6 +27,9 @@ use oat\taoProctoring\model\deliveryLog\DeliveryLog;
 use RuntimeException;
 use oat\ltiDeliveryProvider\model\LtiLaunchDataService as BaseLtiLaunchDataService;
 
+/**
+ * @deprecated
+ */
 class LtiLaunchDataService extends BaseLtiLaunchDataService
 {
     /**


### PR DESCRIPTION
Ticket: [PR-497](https://oat-sa.atlassian.net/browse/PR-497)

Default LTI delivery execution context is set in ltiProctoring DeliveryExecutionCreated event handler. If other extensions want to redefine execution context we should keep it and do not rewrite if execution context already exists.

Requires:
- [x] https://github.com/oat-sa/extension-tao-delivery/pull/515