### PR TITLE
feat: skip proctor authorization with LTI parameter autostart=true

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,12 @@
         "oat-sa/extension-tao-ltideliveryprovider" : ">=12.0.0",
         "oat-sa/extension-tao-lti" : ">=12.0.0",
         "oat-sa/extension-tao-outcomeui" : ">=10.0.0",
-        "oat-sa/extension-tao-proctoring" : ">=20.0.0",
+        "oat-sa/extension-tao-proctoring" : ">=20.2.2",
         "oat-sa/extension-tao-testqti" : ">=41.0.0"
     },
     "autoload" : {
         "psr-4" : {
             "oat\\ltiProctoring\\" : ""
         }
-    } 
+    }
 }

--- a/model/delivery/LtiTestTakerAuthorizationService.php
+++ b/model/delivery/LtiTestTakerAuthorizationService.php
@@ -135,27 +135,24 @@ class LtiTestTakerAuthorizationService extends TestTakerAuthorizationService imp
 
     private function isAutostartEnabled(User $user)
     {
-        $autostartEnabled = false;
         if (!$user instanceof LtiUser) {
-            return $autostartEnabled;
+            return false;
         }
 
         try {
             $ltiLaunchData = $user->getLaunchData();
-            if ($ltiLaunchData->hasVariable(self::CUSTOM_LTI_AUTOSTART)) {
-                $autostartEnabled = $ltiLaunchData->getBooleanVariable(self::CUSTOM_LTI_AUTOSTART);
+            if (!$ltiLaunchData->hasVariable(self::CUSTOM_LTI_AUTOSTART)) {
+                return false;
             }
-            return $autostartEnabled;
+
+            return $ltiLaunchData->getBooleanVariable(self::CUSTOM_LTI_AUTOSTART);
         } catch (LtiException $e) {
             $this->logWarning(
                 "Invalid custom LTI parameter",
-                [
-                    "error" => $e->getMessage(),
-                    "trace" => $e->getTraceAsString()
-                ]
+                ['message' => $e->getMessage(), 'file' => $e->getFile(), 'line' => $e->getLine()]
             );
 
-            return $autostartEnabled;
+            return false;
         }
     }
 }


### PR DESCRIPTION
Handling of custom LTI parameter `autostart=true`, which allows to skip proctor authorization for initial launch.
 
Related to : https://oat-sa.atlassian.net/browse/TR-2736
  
#### How to test
 
Throwaway environment for testing is created and its address can be checked in the related JIRA ticket. 

- Configure a delivery with `Require Proctoring` chechbox checked
- Launch said delivery via LTI 1.1 with added custom parameter `autostart=true`
- Verify that you were redirected to the test, without proctor authorization step
- Then update same delivery and remove checkbox from `Require Proctoring`
- Launch said delivery via LTI 1.1 with added custom parameter `autostart=true` and `proctored=true`
- Verify that again you were redirected to the test, without proctor authorization step
  
#### Dependencies
 
Requires :
 - [ ] https://github.com/oat-sa/extension-tao-proctoring/pull/913
