### PR TITLE
fix: remove unssuported forced static call on PHP 8

### DIFF
--- a/scripts/install/AlterDeliveryMonitoringTable.php
+++ b/scripts/install/AlterDeliveryMonitoringTable.php
@@ -45,7 +45,7 @@ class AlterDeliveryMonitoringTable extends InstallAction
             $dbMigration = new DeliveryMonitoringDbMigration();
             $dbMigration->alterTable($persistence);
 
-            $newPrimaryColumns = array_unique(array_merge(DbSetup::getPrimaryColumns(),$dbMigration->getExtraColumns()));
+            $newPrimaryColumns = array_unique(array_merge((new DbSetup())->getPrimaryColumns(),$dbMigration->getExtraColumns()));
             $monitoringCacheService->setOption(MonitorCacheService::OPTION_PRIMARY_COLUMNS, $newPrimaryColumns);
 
             $this->registerService(MonitorCacheService::SERVICE_ID, $monitoringCacheService);


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105
https://oat-sa.atlassian.net/browse/ADF-1106 (Premium)
https://oat-sa.atlassian.net/browse/ADF-1107 (Premium)

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.